### PR TITLE
Port `DecoderTest` to Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val hpack = crossProject(JVMPlatform, JSPlatform)
     name := "hpack",
     mimaPreviousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % "2.7.0" % Test,
       "io.circe" %%% "circe-parser" % "0.14.1" % Test,
       "com.lihaoyi" %%% "sourcecode" % "0.2.7" % Test,
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ lazy val hpack = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "junit" % "junit" % "4.13.2" % Test,
       "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-      "org.mockito" % "mockito-core" % "1.9.5" % Test,
     )
   )
   .jsSettings(

--- a/hpack/shared/src/test/scala/org/http4s/hpack/DecoderTest.scala
+++ b/hpack/shared/src/test/scala/org/http4s/hpack/DecoderTest.scala
@@ -57,7 +57,7 @@ class MockHeaderListener extends HeaderListener {
   var headers: List[(Array[Byte], Array[Byte], Boolean)] = Nil
 
   def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
-    headers :+= (name, value, sensitive)
+    headers = headers ::: (name, value, sensitive) :: Nil
 
   def reset() = headers = Nil
 
@@ -206,7 +206,7 @@ class DecoderTest {
       mockListener.headers
         .count(
           _ ===
-            (
+            Tuple3(
               DecoderTest.getBytes("name"),
               DecoderTest.getBytes("value"),
               false,


### PR DESCRIPTION
Closes https://github.com/http4s/hpack/issues/11. This wasn't very nice, but got the job done.