### PR TITLE
improve: table size update must come first in header block

### DIFF
--- a/hpack/shared/src/test/scala/org/http4s/hpack/DecoderTest.scala
+++ b/hpack/shared/src/test/scala/org/http4s/hpack/DecoderTest.scala
@@ -33,15 +33,15 @@ package org.http4s.hpack
 
 import cats.kernel.Eq
 import cats.syntax.all._
-
-import java.io.ByteArrayInputStream
-import java.io.IOException
-import org.junit.Before
-import org.junit.Test
 import org.http4s.hpack.HpackUtil.ISO_8859_1
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+import java.io.ByteArrayInputStream
+import java.io.IOException
 
 object DecoderTest {
   private val MAX_HEADER_SIZE = 8192
@@ -141,6 +141,16 @@ class DecoderTest {
     assertEquals(0, decoder.getMaxHeaderTableSize)
     decode("2081")
   }
+
+  @Test(expected = classOf[IOException])
+  @throws[IOException]
+  def testDynamicTableSizeUpdateAfterTheBeginningOfTheBlock(): Unit =
+    decode("8120")
+
+  @Test(expected = classOf[IOException])
+  @throws[Exception]
+  def testDynamicTableSizeUpdateAfterTheBeginningOfTheBlockLong(): Unit =
+    decode("813FE11F")
 
   @Test(expected = classOf[IOException])
   @throws[Exception]


### PR DESCRIPTION
According to RFC 7531, section 4.2, HPACK dynamic table size update must happen at the beginning of the header block.

This change will increase the number of green cases in h2spec, which other HTTP/2 implementation such as hyper/h2(Rust) or Crystal http/2 uses in order to check spec conformance.

References

- https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
- https://github.com/netty/netty/pull/12988
- https://github.com/summerwind/h2spec
- https://github.com/hyperium/h2?tab=readme-ov-file#features
- https://github.com/ysbaddaden/http2